### PR TITLE
fix: print to stdout instead of using logger (which is stderr) also has the side effect of not interpreting formatting verbs

### DIFF
--- a/pkg/cmd/effective/effective.go
+++ b/pkg/cmd/effective/effective.go
@@ -1,6 +1,7 @@
 package effective
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -321,7 +322,7 @@ func (o *Options) displayPipeline(trigger *Trigger, name string, pipeline *tekto
 	}
 
 	log.Logger().Infof("trigger %s pipeline %s", info(trigger.Path), info(name))
-	log.Logger().Infof(string(data))
+	fmt.Print(string(data))
 	return nil
 }
 


### PR DESCRIPTION
Fix so that the any verbs in the pipeline aren't replaced with `%!verb(MISSING)`

for example if a step script contains : ```git log --pretty=format:'{%n  "commit": "%H",%n  "abbreviated_commit": "%h"...}```