### PR TITLE
chore: ensure opentelemetry annotations are not copied

### DIFF
--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -169,7 +169,12 @@ func ToPipelineActivity(pr *v1beta1.PipelineRun, pa *v1.PipelineActivity, overwr
 		pa.Labels = map[string]string{}
 	}
 	for k, v := range annotations {
-		pa.Annotations[k] = v
+		switch k {
+		case "lighthouse.jenkins-x.io/traceparent", "lighthouse.jenkins-x.io/tracestate":
+			// the opentelemetry annotations holding trace context shouldn't be copied to other resources
+		default:
+			pa.Annotations[k] = v
+		}
 	}
 	for k, v := range labels {
 		pa.Labels[k] = v

--- a/pkg/pipelines/test_data/create/pipelinerun.yaml
+++ b/pkg/pipelines/test_data/create/pipelinerun.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     lighthouse.jenkins-x.io/cloneURI: https://github.com/jstrachan/nodey510.git
     lighthouse.jenkins-x.io/job: main
+    lighthouse.jenkins-x.io/traceparent: 00-13e033bb183e42a6bf4c2d497b551502-e6e696ac5966ef63-01
+    lighthouse.jenkins-x.io/tracestate: ""
   creationTimestamp: "2020-09-20T11:57:58Z"
   generateName: main-
   generation: 1

--- a/pkg/pipelines/test_data/initial/pipelinerun.yaml
+++ b/pkg/pipelines/test_data/initial/pipelinerun.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     lighthouse.jenkins-x.io/cloneURI: https://github.com/jstrachan/nodey510.git
     lighthouse.jenkins-x.io/job: release
+    lighthouse.jenkins-x.io/traceparent: 00-13e033bb183e42a6bf4c2d497b551502-e6e696ac5966ef63-01
+    lighthouse.jenkins-x.io/tracestate: ""
   creationTimestamp: "2020-09-29T12:40:38Z"
   generateName: release-
   generation: 1

--- a/pkg/pipelines/test_data/merge/pipelinerun.yaml
+++ b/pkg/pipelines/test_data/merge/pipelinerun.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     lighthouse.jenkins-x.io/cloneURI: https://github.com/jstrachan/nodey510.git
     lighthouse.jenkins-x.io/job: release
+    lighthouse.jenkins-x.io/traceparent: 00-13e033bb183e42a6bf4c2d497b551502-e6e696ac5966ef63-01
+    lighthouse.jenkins-x.io/tracestate: ""
   creationTimestamp: "2020-09-25T07:30:26Z"
   generateName: release-
   generation: 1


### PR DESCRIPTION
when copying pipelinerun annotations to the activity, we need to ensure that some of them won't be copied: the annotations holding the opentelemetry trace context

these are used by https://github.com/jenkins-x/lighthouse-telemetry-plugin to propagate the trace context between different resources (lhjob, pipelinerun, pipelinetask, pod, activity, ...) and should be unique for each resource