### PR TITLE
fix: fixes `SplitBucketURL` to revert the 'min.io' specific change for broken s3 urls

### DIFF
--- a/pkg/cloud/buckets/buckets.go
+++ b/pkg/cloud/buckets/buckets.go
@@ -146,9 +146,5 @@ func WriteBucket(ctx context.Context, bucketURL, key string, reader io.Reader, t
 func SplitBucketURL(u *url.URL) (string, string) {
 	u2 := *u
 	u2.Path = ""
-	if strings.Contains(u2.RawQuery, "minio") {
-		return u2.Scheme + "://" + u2.Host + "?" + strings.SplitN(u.RawQuery, "/", 2)[0], strings.SplitN(u.RawQuery, "/", 2)[1]
-	} else {
-		return u2.String(), strings.TrimPrefix(u.Path, "/")
-	}
+	return u2.String(), strings.TrimPrefix(u.Path, "/")
 }

--- a/pkg/cloud/buckets/buckets_test.go
+++ b/pkg/cloud/buckets/buckets_test.go
@@ -1,5 +1,3 @@
-// +build unit
-
 package buckets_test
 
 import (
@@ -14,7 +12,10 @@ import (
 func TestSplitBucketURL(t *testing.T) {
 	assertSplitBucketURL(t, "s3://foo/my/file", "s3://foo", "my/file")
 	assertSplitBucketURL(t, "gs://mybucket/beer/cheese.txt?param=1234", "gs://mybucket?param=1234", "beer/cheese.txt")
-
+	assertSplitBucketURL(t,
+		"s3://jx3/jenkins-x/logs/org/repo/foo.log?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored",
+		"s3://jx3?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored",
+		"jenkins-x/logs/org/repo/foo.log")
 }
 
 func assertSplitBucketURL(t *testing.T, inputURL string, expectedBucketURL string, expectedKey string) {


### PR DESCRIPTION
prevously the pipeline visualiser urls were being generated incorrectly

for example with a jx-requirements.yaml of the following :

```
  storage:
  - name: logs
    url: s3://jx3?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored/jx3
```

the  `archivedLogsURLTemplate` was transforming this to 

```
s3://jx3?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored/jx3/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.log
```

Which when evaluated resulted in a url like 

```
s3://jx3?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored/jenkins-x/logs/org/repo/foo.log
```

The SplitBucketURL was changed to work with this broken url format in https://github.com/jenkins-x-plugins/jx-pipeline/commit/79f23e0b4ad4a069f87b95a5f4c52d4c8b1278ba

However this s3 url template is generated incorrectly, as it should be

```
s3://jx3/jx3/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch "pr"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.log?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored
```

generating a s3 url like

```
s3://jx3/jenkins-x/logs/org/repo/foo.log?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored
```


https://github.com/jenkins-x/jx3-versions/pull/2488 fixes the s3 url template, and so this PR reverts https://github.com/jenkins-x-plugins/jx-pipeline/commit/79f23e0b4ad4a069f87b95a5f4c52d4c8b1278ba
