### PR TITLE
fix: ensure we don't loop while reading pod logs

### DIFF
--- a/pkg/tektonlog/tektonlog.go
+++ b/pkg/tektonlog/tektonlog.go
@@ -267,13 +267,25 @@ func (t *TektonLogger) getRunningBuildLogs(ctx context.Context, pa *v1.PipelineA
 			if err != nil {
 				return errors.Wrapf(err, "failed to load pod %s in namespace %s", podName, t.Namespace)
 			}
-			if pods.IsPodCompleted(pod) {
-				completedPods[podName] = true
-			}
 
 			err = t.getContainerLogsFromPod(ctx, pod, pa, buildName, stageName, out)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get logs for pod %s", podName)
+			}
+
+			// let's reload the pod to see if it's completed or not (it should, now that we've streamed its logs)
+			pod, err = t.KubeClient.CoreV1().Pods(t.Namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil && apierrors.IsNotFound(err) {
+				if pa.Spec.Status == v1.ActivityStatusTypeRunning {
+					pa.Spec.Status = v1.ActivityStatusTypeAborted
+				}
+				return nil
+			}
+			if err != nil {
+				return errors.Wrapf(err, "failed to load pod %s in namespace %s", podName, t.Namespace)
+			}
+			if pods.IsPodCompleted(pod) {
+				completedPods[podName] = true
 			}
 		}
 


### PR DESCRIPTION
see https://github.com/jenkins-x-plugins/jx-build-controller/issues/30

we used to mark the pod as "completed" before reading its logs. which means that a running pod was never marked as "completed" until the 2nd loop, which means that the logs are seen as "duplicated".

the fix here is to check if the pod is completed after reading its logs - which should be the case, because we're waiting for each container.