### PR TITLE
chore: adding back code I removed in previous PR https://github.com/j…

### DIFF
--- a/pkg/lighthouses/resolvers.go
+++ b/pkg/lighthouses/resolvers.go
@@ -46,18 +46,38 @@ func (o *ResolverOptions) CreateResolver() (*inrepo.UsesResolver, error) {
 	}
 
 	if fb == nil {
+		gitCloneUser := f.GitUsername
+		token := f.GitToken
 		if f.GitServerURL == "" {
 			f.GitServerURL = "https://github.com"
 		}
 
+		var gitServerURL *url.URL
 		if f.GitServerURL != "" {
+			gitServerURL, err = url.Parse(f.GitServerURL)
 			_, err = url.Parse(f.GitServerURL)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to parse git URL %s", f.GitServerURL)
 			}
 		}
 
-		configureOpts := func(opts *gitv2.ClientFactoryOpts) {}
+		configureOpts := func(opts *gitv2.ClientFactoryOpts) {
+			opts.Token = func() []byte {
+				return []byte(token)
+			}
+			opts.GitUser = func() (name, email string, err error) {
+				name = gitCloneUser
+				return
+			}
+			opts.Username = func() (login string, err error) {
+				login = gitCloneUser
+				return
+			}
+			if gitServerURL != nil {
+				opts.Host = gitServerURL.Host
+				opts.Scheme = gitServerURL.Scheme
+			}
+		}
 		gitFactory, err := gitv2.NewClientFactory(configureOpts)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create git factory")


### PR DESCRIPTION
…enkins-x-plugins/jx-pipeline/pull/396/files\#diff-e4be9548543760fb080f81faf6974ea8fa32fe619bf82518a3685e8341d55e66L63

https://github.com/jenkins-x-plugins/jx-pipeline/pull/396

On second thought this code might be needed for working with private repos,
it still causes bad entries getting added to users ~/.gitcredentials files
but lets look at fixing that seperately from the lighthouse-client upgrade
in the other PR mentioned above.