### PR TITLE
fix: build number bug with single build

### DIFF
--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -56,7 +56,7 @@ func ToPipelineActivityName(pr *v1beta1.PipelineRun, paList []v1.PipelineActivit
 			pa := &paList[i]
 			if strings.HasPrefix(pa.Name, prefix) {
 				buildNum, _ := strconv.Atoi(strings.Split(pa.Name, prefix)[1])
-				if buildNum > b {
+				if buildNum >= b {
 					b = buildNum
 					found = true
 				}

--- a/pkg/pipelines/pipelines_test.go
+++ b/pkg/pipelines/pipelines_test.go
@@ -109,6 +109,17 @@ func generatePipelineRunWithLabels(branch, org, repo, buildNum string) *v1beta1.
 var paList = []v1.PipelineActivity{
 	{
 		ObjectMeta: metav1.ObjectMeta{
+			Name: "jenkins-x-plugins-jx-pipeline-pr-404-1",
+			Labels: map[string]string{
+				branchLabel:   "PR-404",
+				orgLabel:      TestOrg,
+				repoLabel:     PipelineRepo,
+				buildNumLabel: "1601383238723",
+			},
+		},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "jenkins-x-plugins-jx-pipeline-master-2",
 			Labels: map[string]string{
 				branchLabel:   "master",
@@ -162,6 +173,12 @@ var BuildNumberTestCases = []struct {
 	paList               []v1.PipelineActivity
 	expectedActivityName string
 }{
+	{
+		"Create pa with build number 2 for second pipeline of a given prefix",
+		generatePipelineRunWithLabels("pr-404", TestOrg, "jx-pipeline", "16013832387908"),
+		paList,
+		"jenkins-x-plugins-jx-pipeline-pr-404-2",
+	},
 	{
 		"Create pa with build number one for first pipeline of a given prefix",
 		generatePipelineRunWithLabels("master", TestOrg, "jx-promote", "16013832387908"),


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

New test failed for old code with this error:
```
=== RUN   TestPipelineBuildNumber
    pipelines_test.go:217: Create pa with build number 2 for second pipeline of a given prefix
    pipelines_test.go:218: 
        	Error Trace:	pipelines_test.go:218
        	Error:      	Not equal: 
        	            	expected: "jenkins-x-plugins-jx-pipeline-pr-404-2"
        	            	actual  : "jenkins-x-plugins-jx-pipeline-pr-404-1"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-jenkins-x-plugins-jx-pipeline-pr-404-2
        	            	+jenkins-x-plugins-jx-pipeline-pr-404-1
        	Test:       	TestPipelineBuildNumber
--- FAIL: TestPipelineBuildNumber (0.00s)
FAIL
exit status 1
FAIL	github.com/jenkins-x-plugins/jx-pipeline/pkg/pipelines	0.011s
```

So, if someone opens a new PR, the build number will be 1, but the next builds will not increment. 
I was checking for only greater than and not greater than or equal to. 