### PR TITLE
refactor: use T.TempDir to create temporary test directory

### DIFF
--- a/pkg/cmd/convert/convert_test.go
+++ b/pkg/cmd/convert/convert_test.go
@@ -1,7 +1,6 @@
 package convert_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,8 +36,7 @@ func TestConvertCatalog(t *testing.T) {
 	if generateTestOutput {
 		os.RemoveAll(expectedDir)
 	} else {
-		tmpDir, err = ioutil.TempDir("", "")
-		require.NoError(t, err, "could not create temp dir")
+		tmpDir = t.TempDir()
 	}
 
 	err = files.CopyDir(srcDir, tmpDir, true)
@@ -75,8 +73,7 @@ func TestConvertRepository(t *testing.T) {
 	if generateTestOutput {
 		os.RemoveAll(expectedDir)
 	} else {
-		tmpDir, err = ioutil.TempDir("", "")
-		require.NoError(t, err, "could not create temp dir")
+		tmpDir = t.TempDir()
 	}
 
 	err = files.CopyDir(srcDir, tmpDir, true)

--- a/pkg/cmd/effective/effective_jenkins_integration_test.go
+++ b/pkg/cmd/effective/effective_jenkins_integration_test.go
@@ -33,8 +33,7 @@ var (
 )
 
 func TestPipelineEffectiveJenkinsClientWithEnvVar(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 	actual := filepath.Join(tmpDir, "pipeline.yaml")
 	expectedFile := filepath.Join("test_data", ".lighthouse", "jenkins-x", "expected-int.yaml")
 
@@ -51,7 +50,7 @@ func TestPipelineEffectiveJenkinsClientWithEnvVar(t *testing.T) {
 	o.AddDefaults = true
 	o.OutFile = actual
 	o.Resolver = CreateFakeResolver(t)
-	err = o.Run()
+	err := o.Run()
 	require.NoError(t, err, "Failed to run linter")
 
 	assert.FileExists(t, actual, "should have generated file")
@@ -71,12 +70,11 @@ func TestPipelineEffectiveJenkinsClientWithEnvVar(t *testing.T) {
 }
 
 func TestPipelineEffectiveJenkinsClientDiscoverGit(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 	actual := filepath.Join(tmpDir, "pipeline.yaml")
 	expectedFile := filepath.Join("test_data", ".lighthouse", "jenkins-x", "expected-int.yaml")
 
-	err = files.CopyDirOverwrite("test_data", tmpDir)
+	err := files.CopyDirOverwrite("test_data", tmpDir)
 	require.NoError(t, err, "failed to copy test_data to %s", tmpDir)
 
 	gitDir := filepath.Join(tmpDir, ".git")

--- a/pkg/cmd/effective/effective_test.go
+++ b/pkg/cmd/effective/effective_test.go
@@ -1,7 +1,6 @@
 package effective_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -28,8 +27,7 @@ var (
 )
 
 func TestPipelineEffective(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 	actual := filepath.Join(tmpDir, "pipeline.yaml")
 	expectedFile := filepath.Join("test_data", ".lighthouse", "jenkins-x", "expected.yaml")
 
@@ -39,7 +37,7 @@ func TestPipelineEffective(t *testing.T) {
 	o.BatchMode = true
 	o.OutFile = actual
 	o.Resolver = CreateFakeResolver(t)
-	err = o.Run()
+	err := o.Run()
 	require.NoError(t, err, "Failed to run linter")
 
 	assert.FileExists(t, actual, "should have generated file")

--- a/pkg/cmd/importcmd/import_test.go
+++ b/pkg/cmd/importcmd/import_test.go
@@ -1,7 +1,6 @@
 package importcmd_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -13,11 +12,10 @@ import (
 )
 
 func TestPipelineImport(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	dir := t.TempDir()
 
 	srcDir := "test_data"
-	err = files.CopyDir(srcDir, dir, true)
+	err := files.CopyDir(srcDir, dir, true)
 	require.NoError(t, err, "failed to copy from %s to %s", srcDir, dir)
 
 	t.Logf("running tests in dir %s\n", dir)

--- a/pkg/cmd/override/override_test.go
+++ b/pkg/cmd/override/override_test.go
@@ -1,7 +1,6 @@
 package override_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -22,13 +21,12 @@ var (
 )
 
 func TestPipelineOverrideStep(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data", "step")
 	expectedFile := filepath.Join(srcDir, "expected.yaml")
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcDir, tmpDir)
 
 	_, o := override.NewCmdPipelineOverride()
@@ -54,13 +52,12 @@ func TestPipelineOverrideStep(t *testing.T) {
 }
 
 func TestPipelineOverrideStepProperty(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data", "step-property")
 	expectedFile := filepath.Join(srcDir, "expected.yaml")
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy %s to %s", srcDir, tmpDir)
 
 	_, o := override.NewCmdPipelineOverride()
@@ -87,8 +84,7 @@ func TestPipelineOverrideStepProperty(t *testing.T) {
 }
 
 func TestPipelineOverrideTask(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := filepath.Join("test_data", "task")
 	expectedFile := filepath.Join(srcDir, "expected.yaml")

--- a/pkg/cmd/set/set_test.go
+++ b/pkg/cmd/set/set_test.go
@@ -19,12 +19,11 @@ var (
 func TestPipelineSet(t *testing.T) {
 	_, o := set.NewCmdPipelineSet()
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create tmp dir")
+	tmpDir := t.TempDir()
 
 	srcDir := "test_data"
 
-	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	err := files.CopyDirOverwrite(srcDir, tmpDir)
 	require.NoError(t, err, "failed to copy test files at %s to %s", srcDir, tmpDir)
 
 	o.Dir = tmpDir

--- a/pkg/pipelines/pipelines_test.go
+++ b/pkg/pipelines/pipelines_test.go
@@ -39,8 +39,7 @@ func AssertPipelineActivityMapping(t *testing.T, folder string) {
 	prFile := filepath.Join("test_data", folder, "pipelinerun.yaml")
 	require.FileExists(t, prFile)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp dir")
+	tmpDir := t.TempDir()
 
 	data, err := ioutil.ReadFile(prFile)
 	require.NoError(t, err, "failed to load %s", prFile)
@@ -70,11 +69,10 @@ func TestMergePipelineActivity(t *testing.T) {
 	paFile := filepath.Join("test_data", "merge", "pa.yaml")
 	require.FileExists(t, prFile)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp dir")
+	tmpDir := t.TempDir()
 
 	pr := &v1beta1.PipelineRun{}
-	err = yamls.LoadFile(prFile, pr)
+	err := yamls.LoadFile(prFile, pr)
 	require.NoError(t, err, "failed to load %s", prFile)
 
 	pa := &v1.PipelineActivity{}


### PR DESCRIPTION
Follow up PR for https://github.com/jenkins-x-plugins/jx-gitops/pull/839#issuecomment-1079479757. This PR replaces `ioutil.TempDir` with `t.TempDir` in tests.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir