### PR TITLE
fix: start fails with SEGSEGV

### DIFF
--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -500,7 +500,7 @@ func (o *Options) createLighthouseJob(jobName string, cfg *config.Config) error 
 	launchClient := launcher.NewLauncher(o.LHClient, o.Namespace)
 	lhjob, err = launchClient.Launch(lhjob)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create lighthousejob %s in namespace %s", lhjob.Name, ns)
+		return errors.Wrapf(err, "failed to create lighthousejob in namespace %s", ns)
 	}
 
 	log.Logger().Infof("created lighthousejob %s in namespace %s", info(lhjob.Name), info(ns))


### PR DESCRIPTION
Got

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x29f64e2]

goroutine 1 [running]:
github.com/jenkins-x-plugins/jx-pipeline/pkg/cmd/start.(*Options).createLighthouseJob(0xc000252840, 0xc00005b9e0, 0x23, 0xc00079f8c0, 0x2f77fcb, 0x25)
	/workspace/source/pkg/cmd/start/start.go:503 +0xe22
```

when lighthouse job wasn't created, since `lhjob` was null. This fix makes the actual problem being printed.