### PR TITLE
Adding Target to build darwin arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,10 @@ win: ## Build for Windows
 darwin: ## Build for OSX
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=amd64 $(GO) $(BUILD_TARGET) $(BUILDFLAGS) -o build/darwin/$(BINARY_NAME) $(MAIN_SRC_FILE)
 	chmod +x build/darwin/$(BINARY_NAME)
+	
+darwin-arm: ## Build for OSX
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=arm64 $(GO) $(BUILD_TARGET) $(BUILDFLAGS) -o build/darwin-arm64/$(BINARY_NAME) $(MAIN_SRC_FILE)
+	chmod +x build/darwin-arm/$(BINARY_NAME)
 
 .PHONY: release
 release: clean linux test


### PR DESCRIPTION
Adding the target to build on the M1 mac.

This PR will also depend on https://github.com/jenkins-x/jx-helpers/pull/369