### PR TITLE
fix: https clone url

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,4 @@
 approvers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- ankitm123
+- maintainers
 reviewers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- ankitm123
+- maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,3 @@
-aliases:
-- rawlingsj
-best-approvers:
-- rawlingsj
-best-reviewers:
-- rawlingsj
+foreignAliases:
+- name: jx-context
+  org: jenkins-x

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -313,6 +313,9 @@ func (o *Options) processFile(path string) error {
 	if gitCloneURL == "" {
 		gitCloneURL = gitURL
 	}
+	if gitInfo.Scheme == "git" {
+		gitCloneURL = gitInfo.HttpsURL()
+	}
 	owner := gitInfo.Organisation
 	repo := gitInfo.Name
 

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -309,13 +309,7 @@ func (o *Options) processFile(path string) error {
 		return errors.Wrapf(err, "failed to discover git url")
 	}
 	gitURL := gitInfo.URL
-	gitCloneURL := gitInfo.CloneURL
-	if gitCloneURL == "" {
-		gitCloneURL = gitURL
-	}
-	if gitInfo.Scheme == "git" {
-		gitCloneURL = gitInfo.HttpsURL()
-	}
+	gitCloneURL := gitInfo.HttpsURL()
 	owner := gitInfo.Organisation
 	repo := gitInfo.Name
 


### PR DESCRIPTION
Fix clone url when using --file in repo checked out with ssh

Now the build otherwise fail, for example with:

```
+ git clone git@github.com:foo/bargit source
Cloning into 'source'...
Host key verification failed.
fatal: Could not read from remote repository.
```
