### PR TITLE
fix: skip interactive prompts when git credentials are provided (#8421)

### DIFF
--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -176,6 +176,10 @@ func (o *Options) Validate() error {
 	if o.Input == nil {
 		o.Input = inputfactory.NewInput(&o.BaseOptions)
 	}
+
+	if o.GitUsername != "" || o.GitToken != "" {
+		o.BatchMode = true
+	}
 	o.customParameterMap = map[string]string{}
 	for _, cp := range o.CustomParameters {
 		paths := strings.SplitN(cp, "=", 2)


### PR DESCRIPTION
This PR fixes jenkins-x/jx#8421.

It ensures that when `--git-username` or `--git-token` flags are provided, the command enables `BatchMode` to bypass interactive prompts. This is essential for non-interactive/automated environments.

I have verified this by:
1. Running `make build` to ensure successful compilation.
2. Running `go test ./pkg/cmd/start/...` (all tests passed).
3. Manually verifying that the interactive prompt is skipped when flags are provided.