### PR TITLE
fix(pipelineactivity): prevent duplicate stage and nil-deref on merge

### DIFF
--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -288,13 +288,17 @@ func ToPipelineActivity(tektonclient tektonversioned.Interface, pr *pipelinev1.P
 				if idx < 0 {
 					ps.Steps = append(ps.Steps, stage)
 				} else {
-					// lets add the new stage before the preview/promote stages
-					var remaining []v1.PipelineActivityStep
-					if idx < len(ps.Steps) {
-						remaining = ps.Steps[idx:]
-					}
-					ps.Steps = append(ps.Steps[0:idx], stage)
-					ps.Steps = append(ps.Steps, remaining...)
+					// Insert the new stage before the first Preview/Promote.
+					// Build a brand-new slice instead of reslicing in place:
+					// ps.Steps[idx:] aliases the same backing array as
+					// append(ps.Steps[0:idx], stage), so the append overwrites
+					// slot idx and the captured tail then re-reads the new
+					// stage — duplicating it and losing the Preview/Promote.
+					newSteps := make([]v1.PipelineActivityStep, 0, len(ps.Steps)+1)
+					newSteps = append(newSteps, ps.Steps[:idx]...)
+					newSteps = append(newSteps, stage)
+					newSteps = append(newSteps, ps.Steps[idx:]...)
+					ps.Steps = newSteps
 				}
 			}
 		}
@@ -302,14 +306,7 @@ func ToPipelineActivity(tektonclient tektonversioned.Interface, pr *pipelinev1.P
 		// if the PipelineActivity has some real steps lets trust it; otherwise lets merge any preview/promote steps
 		// with steps from the PipelineRun
 		// lets add any missing steps from the PipelineActivity as they may have been created via a `jx promote` step
-		hasStep := false
-		for _, s := range ps.Steps {
-			if s.Kind == v1.ActivityStepKindTypeStage && s.Stage != nil && s.Stage.Name != "Release" {
-				hasStep = true
-				break
-			}
-		}
-		if !hasStep {
+		if len(pipelineStages(pa)) == 0 {
 			for _, s := range ps.Steps {
 				if s.Kind == v1.ActivityStepKindTypePreview || s.Kind == v1.ActivityStepKindTypePromote {
 					steps = append(steps, s)
@@ -373,23 +370,40 @@ func addConditionsMessage(pr *pipelinev1.PipelineRun, pa *v1.PipelineActivity) {
 	}
 }
 
+// pipelineStages returns Spec.Steps entries that correspond to real Tekton
+// pipeline tasks. Skips Preview/Promote (Stage is nil) and the legacy
+// "Release" placeholder from jx-helpers' GetOrCreatePreview/Promote — a
+// follow-up PR removes the producer; the Release branch here can go once
+// old PAs have been recycled.
+//
+// Returned pointers reference entries inside pa.Spec.Steps so callers can
+// mutate the underlying stage.
+func pipelineStages(pa *v1.PipelineActivity) []*v1.PipelineActivityStep {
+	out := make([]*v1.PipelineActivityStep, 0, len(pa.Spec.Steps))
+	for i := range pa.Spec.Steps {
+		s := &pa.Spec.Steps[i]
+		if s.Stage == nil || s.Stage.Name == "Release" {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
 // addConditionsMessage reads the pr and gets the message for each taskrun then add it to the pa as Spec.Steps[k].Stage.Message
 // It replace TaskRun with Stage
 func addTaskRunsMessage(taskruns []pipelinev1.TaskRun, pa *v1.PipelineActivity) {
-	k1 := 0
+	stages := pipelineStages(pa)
 	for i := range taskruns {
-		taskrun := taskruns[i]
+		if i >= len(stages) {
+			break
+		}
 		msg := ""
-		for k2 := range taskrun.Status.Conditions {
-			msg = taskrun.Status.Conditions[k2].Message
+		for k := range taskruns[i].Status.Conditions {
+			msg = taskruns[i].Status.Conditions[k].Message
 		}
 		msg = strings.ReplaceAll(msg, "TaskRun", "Stage")
-		// Without this check, there is a panic in the codebase
-		// ToDo(@maintainers): Test case for this
-		if len(pa.Spec.Steps) > k1 {
-			pa.Spec.Steps[k1].Stage.Message = v1.ActivityMessageType(msg)
-		}
-		k1++
+		stages[i].Stage.Message = v1.ActivityMessageType(msg)
 	}
 }
 

--- a/pkg/pipelines/pipelines_internal_test.go
+++ b/pkg/pipelines/pipelines_internal_test.go
@@ -1,0 +1,244 @@
+package pipelines
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/jenkins-x/jx-api/v4/pkg/apis/jenkins.io/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	tektonfake "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// jx-build-controller crashed in production with a nil pointer deref because
+// PipelineActivity.Spec.Steps had a Preview entry (written by jx-preview) at
+// an index addTaskRunsMessage tried to write to. PipelineActivityStep.Stage
+// is nil for non-Stage kinds, so positional indexing dereferenced nil.
+func TestAddTaskRunsMessageSkipsNonStageSteps(t *testing.T) {
+	pa := &v1.PipelineActivity{
+		Spec: v1.PipelineActivitySpec{
+			Steps: []v1.PipelineActivityStep{
+				{
+					Kind:    v1.ActivityStepKindTypePreview,
+					Preview: &v1.PreviewActivityStep{ApplicationURL: "https://preview.example"},
+				},
+				{
+					Kind: v1.ActivityStepKindTypeStage,
+					Stage: &v1.StageActivityStep{
+						CoreActivityStep: v1.CoreActivityStep{Name: "build"},
+					},
+				},
+			},
+		},
+	}
+	taskruns := []pipelinev1.TaskRun{
+		{
+			Status: pipelinev1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: []apis.Condition{
+						{Message: "TaskRun build succeeded"},
+					},
+				},
+			},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		addTaskRunsMessage(taskruns, pa)
+	})
+
+	assert.Equal(t, "Stage build succeeded", pa.Spec.Steps[1].Stage.Message.String())
+}
+
+func makeTerminatedTaskRun(name, ns, taskName string) *pipelinev1.TaskRun {
+	finished := metav1.Time{Time: metav1.Now().Time}
+	return &pipelinev1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{"tekton.dev/pipelineTask": taskName},
+		},
+		Status: pipelinev1.TaskRunStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{
+					{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+				},
+			},
+			TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+				Steps: []pipelinev1.StepState{
+					{
+						Name: "step-main",
+						ContainerState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode:   0,
+								StartedAt:  finished,
+								FinishedAt: finished,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Walk the real lifecycle that triggered the production bug:
+//
+//  1. The PipelineRun starts with the parallel tasks (frontend-tests,
+//     backend-tests, build-and-deploy). jx-build-controller reconciles and
+//     populates three Stage entries in the PipelineActivity.
+//  2. Mid-build, build-and-deploy's `promote-jx-preview` step runs
+//     `jx preview create`, which APPENDS a Preview step to pa.Spec.Steps.
+//  3. frontend-tests + backend-tests complete; Tekton creates the sonar
+//     TaskRun (it has runAfter on both). The PipelineRun's ChildReferences
+//     now include sonar. jx-build-controller reconciles again.
+//
+// The bug was that step 3's reconcile inserted the new sonar Stage *before*
+// the Preview using slice-aliasing-prone code, which overwrote the Preview
+// slot and duplicated sonar. The dashboard then showed a phantom Running
+// stage and lost the preview URL.
+//
+// This test reproduces the exact sequence and asserts that no Stage gets
+// duplicated and the Preview (URL and all) survives.
+func TestToPipelineActivityLifecycleDoesNotCorruptPreview(t *testing.T) {
+	ns := "jx"
+	pa := &v1.PipelineActivity{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+	client := tektonfake.NewSimpleClientset()
+
+	// Step 1: parallel tasks running, sonar not yet created (Tekton hasn't
+	// scheduled it because its runAfter prerequisites are not met yet).
+	parallelRefs := []pipelinev1.ChildStatusReference{
+		{Name: "tr-frontend-tests", PipelineTaskName: "frontend-tests"},
+		{Name: "tr-backend-tests", PipelineTaskName: "backend-tests"},
+		{Name: "tr-build-and-deploy", PipelineTaskName: "build-and-deploy"},
+	}
+	pr := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "pr-test", Namespace: ns},
+		Status: pipelinev1.PipelineRunStatus{
+			PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+				ChildReferences: parallelRefs,
+			},
+		},
+	}
+	for _, ref := range parallelRefs {
+		_, err := client.TektonV1().TaskRuns(ns).Create(
+			context.Background(),
+			makeTerminatedTaskRun(ref.Name, ns, ref.PipelineTaskName),
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+
+	// First reconcile: three Stage entries, no Preview yet.
+	require.NoError(t, ToPipelineActivity(client, pr, pa, true))
+	require.Len(t, pa.Spec.Steps, 3, "expected one Stage per parallel task")
+
+	// Step 2: build-and-deploy's promote-jx-preview step runs `jx preview
+	// create`, which APPENDS a Preview entry via GetOrCreatePreview. We
+	// simulate that direct write here.
+	pa.Spec.Steps = append(pa.Spec.Steps, v1.PipelineActivityStep{
+		Kind: v1.ActivityStepKindTypePreview,
+		Preview: &v1.PreviewActivityStep{
+			Environment:    "preview",
+			ApplicationURL: "https://alinapos-pr-404.preview.example",
+			PullRequestURL: "https://gitlab.com/alinapos/alinapos/-/merge_requests/404",
+		},
+	})
+
+	// Step 3: tests finish, Tekton schedules sonar, ChildReferences grows.
+	pr.Status.ChildReferences = append(parallelRefs, pipelinev1.ChildStatusReference{
+		Name: "tr-sonar", PipelineTaskName: "sonar",
+	})
+	_, err := client.TektonV1().TaskRuns(ns).Create(
+		context.Background(),
+		makeTerminatedTaskRun("tr-sonar", ns, "sonar"),
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	// Second reconcile: this is where the slice-aliasing bug fires today.
+	require.NoError(t, ToPipelineActivity(client, pr, pa, true))
+
+	var stageNames []string
+	previewCount := 0
+	var previewURL, previewPRURL string
+	for _, s := range pa.Spec.Steps {
+		switch s.Kind {
+		case v1.ActivityStepKindTypeStage:
+			require.NotNil(t, s.Stage)
+			stageNames = append(stageNames, s.Stage.Name)
+		case v1.ActivityStepKindTypePreview:
+			previewCount++
+			require.NotNil(t, s.Preview)
+			previewURL = s.Preview.ApplicationURL
+			previewPRURL = s.Preview.PullRequestURL
+		}
+	}
+	assert.Equal(t,
+		[]string{"frontend tests", "backend tests", "build and deploy", "sonar"},
+		stageNames,
+		"every PipelineTask must appear exactly once as a Stage")
+	assert.Equal(t, 1, previewCount, "the Preview entry must not be lost or duplicated")
+	assert.Equal(t,
+		"https://alinapos-pr-404.preview.example",
+		previewURL,
+		"Preview ApplicationURL must survive the reconcile that adds sonar")
+	assert.Equal(t,
+		"https://gitlab.com/alinapos/alinapos/-/merge_requests/404",
+		previewPRURL,
+		"Preview PullRequestURL must survive the reconcile that adds sonar")
+}
+
+// Reconciliation must converge: once the build is fully done and the
+// activity is up to date, running ToPipelineActivity again must produce a
+// stable Spec.Steps. Otherwise repeated controller reconciles keep mutating
+// the activity, accreting drift over time.
+func TestToPipelineActivityIsIdempotent(t *testing.T) {
+	ns := "jx"
+	pa := &v1.PipelineActivity{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+	client := tektonfake.NewSimpleClientset()
+
+	refs := []pipelinev1.ChildStatusReference{
+		{Name: "tr-frontend-tests", PipelineTaskName: "frontend-tests"},
+		{Name: "tr-backend-tests", PipelineTaskName: "backend-tests"},
+		{Name: "tr-build-and-deploy", PipelineTaskName: "build-and-deploy"},
+		{Name: "tr-sonar", PipelineTaskName: "sonar"},
+	}
+	pr := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "pr-test", Namespace: ns},
+		Status: pipelinev1.PipelineRunStatus{
+			PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{ChildReferences: refs},
+		},
+	}
+	for _, ref := range refs {
+		_, err := client.TektonV1().TaskRuns(ns).Create(
+			context.Background(),
+			makeTerminatedTaskRun(ref.Name, ns, ref.PipelineTaskName),
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+	pa.Spec.Steps = append(pa.Spec.Steps, v1.PipelineActivityStep{
+		Kind: v1.ActivityStepKindTypePreview,
+		Preview: &v1.PreviewActivityStep{
+			ApplicationURL: "https://preview.example",
+		},
+	})
+
+	require.NoError(t, ToPipelineActivity(client, pr, pa, true))
+	first := pa.DeepCopy()
+
+	require.NoError(t, ToPipelineActivity(client, pr, pa, true))
+
+	require.Equal(t, len(first.Spec.Steps), len(pa.Spec.Steps),
+		"Steps length must be stable across repeated reconciles")
+	for i := range first.Spec.Steps {
+		assert.Equal(t, first.Spec.Steps[i].Kind, pa.Spec.Steps[i].Kind,
+			"Steps[%d].Kind diverged across reconciles", i)
+	}
+}


### PR DESCRIPTION
- Replace slice-aliasing splice with a fresh slice copy, so inserting a new Stage before an existing Preview/Promote no longer overwrites that slot and duplicates the stage.
- Filter Spec.Steps via a new pipelineStages helper before indexing in addTaskRunsMessage, so Preview/Promote entries (Stage == nil) and the legacy "Release" placeholder don't cause panics or misattribute messages.

Adds white-box tests reproducing both bugs against the production lifecycle.