### PR TITLE
chore: update coverage report to go 1.26.3

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -27,7 +27,7 @@ spec:
             requests:
               cpu: 1400m
               memory: 600Mi
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: coverage-report
           resources: {}
           script: |


### PR DESCRIPTION
- update go version in coverage report within release step 
- part of https://github.com/jenkins-x/jx/issues/8965